### PR TITLE
Fix syntax of shell commands removing dollar sign ($)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ Focus is written in Go, so you can install it through `go install` (requires Go
 1.16 or later):
 
 ```bash
-$ go install github.com/ayoisaiah/focus/cmd/focus@latest
+go install github.com/ayoisaiah/focus/cmd/focus@latest
 ```
 
 On Linux, the `libasound2-dev` package is required to compile Focus. Ubuntu or
 Debian users can install it through the command below:
 
 ```bash
-$ sudo apt install libasound2-dev
+sudo apt install libasound2-dev
 ```
 
 ### 📦 NPM Package
@@ -71,13 +71,13 @@ You can also install Focus through its
 With `npm`:
 
 ```bash
-$ npm i @ayoisaiah/focus -g
+npm i @ayoisaiah/focus -g
 ```
 
 With `yarn`:
 
 ```bash
-$ yarn global add @ayoisaiah/focus
+yarn global add @ayoisaiah/focus
 ```
 
 Other installation methods are
@@ -88,7 +88,7 @@ Other installation methods are
 Once Focus is installed, run it using the command below:
 
 ```
-$ focus
+focus
 ```
 
 **Note:** Only one instance of `focus` can be active at a time.


### PR DESCRIPTION
When copying with the integrated copy button, the shell symbol ($) gets copied as well, resulting in having to fix the pasted command before being able to run it.
Example of copy pasting dependency installation:
![image](https://github.com/ayoisaiah/focus/assets/91565194/01f4db09-e9f8-4073-a148-edfa33420d56)
![image](https://github.com/ayoisaiah/focus/assets/91565194/183cf0fd-7e2c-4ab0-b9d9-ed092c1c8a71)
![image](https://github.com/ayoisaiah/focus/assets/91565194/6799fb5a-062e-4750-b09d-11b067df5fe6)
